### PR TITLE
Providing exception translator for adding error messages

### DIFF
--- a/src/main/java/jensfischerhh/constraintvalidation/ConstraintViolationExceptionMessageEnricher.java
+++ b/src/main/java/jensfischerhh/constraintvalidation/ConstraintViolationExceptionMessageEnricher.java
@@ -1,0 +1,33 @@
+package jensfischerhh.constraintvalidation;
+
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolationException;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
+
+/**
+ * Translates {@link ConstraintViolationException}s into {@link DataIntegrityViolationException}s, adding
+ * property path and message for all contained constraint violations to the exception message.
+ *
+ * @author Gunnar Morling
+ */
+public class ConstraintViolationExceptionMessageEnricher implements PersistenceExceptionTranslator {
+
+	@Override
+	public DataAccessException translateExceptionIfPossible(RuntimeException ex) {
+		if (ex instanceof ConstraintViolationException) {
+			String message = ex.getMessage() + System.lineSeparator();
+			message += ( (ConstraintViolationException) ex ).getConstraintViolations()
+				.stream()
+				.map( cv -> cv.getPropertyPath() + ": " + cv.getMessage() )
+				.collect( Collectors.joining( ";" + System.lineSeparator() ) );
+
+			return new DataIntegrityViolationException( message, ex );
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/jensfischerhh/constraintvalidation/JpaConfiguration.java
+++ b/src/main/java/jensfischerhh/constraintvalidation/JpaConfiguration.java
@@ -10,7 +10,9 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
 import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter;
 import org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter;
 import org.springframework.transaction.jta.JtaTransactionManager;
@@ -36,5 +38,10 @@ public class JpaConfiguration extends JpaBaseConfiguration {
         Map<String, Object> vendorProperties = new HashMap<>(getProperties().getProperties());
         vendorProperties.put(PersistenceUnitProperties.WEAVING, "false");
         return vendorProperties;
+    }
+
+    @Bean
+    public PersistenceExceptionTranslator validationMessageEnricher() {
+        return new ConstraintViolationExceptionMessageEnricher();
     }
 }

--- a/src/test/java/jensfischerhh/constraintvalidation/ApplicationTests.java
+++ b/src/test/java/jensfischerhh/constraintvalidation/ApplicationTests.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,17 +44,17 @@ public class ApplicationTests {
         String name = "Name-Which-Is-Way-Too-Long";
 
         // WHEN
-        ConstraintViolationException cause = (ConstraintViolationException) catchThrowable(() ->
+        DataIntegrityViolationException exception = (DataIntegrityViolationException) catchThrowable(() ->
                 repository.saveAndFlush(new Person(name))
         );
-        cause.printStackTrace();
+        exception.printStackTrace();
 
         // THEN
-        then(cause.getConstraintViolations())
+        then(((ConstraintViolationException)exception.getCause()).getConstraintViolations())
                 .isNotEmpty()
                 .extracting(ConstraintViolation::getMessage)
                 .containsOnly("length must be between 1 and 20");
-        then(cause)
+        then(exception)
                 .hasMessageContaining("length must be between 1 and 20")
                 .describedAs("missing violation detail message");
     }


### PR DESCRIPTION
Hallo Jens, hier mit etwas Verspätung eine Antwort auf Deine Frage von den code.talks.

Ich würde empfehlen, einen Interceptor / Exception-Handler o.ä. zu registrieren, der `ConstraintViolationException`s abfängt und die Exception-Message mit den Property-Namen, Fehlermeldungen etc. der enthaltenen `ConstraintViolation`s anreichert. Hier als Beispiel habe ich einfach einen `PersistenceExceptionTranslator` implementiert, aber je nach Eurer Architektur könnte aber z.B. auch ein Exception Mapper für MVC geeigneter sein. Das generelle Prinzip sollte aber das gleiche sein.

Würde Euch das so weiterhelfen?

Viele Grüße,

--Gunnar